### PR TITLE
Parametrize ActivityHostFragment

### DIFF
--- a/map-fragment/src/com/inazaruk/example/ActivityHostFragment.java
+++ b/map-fragment/src/com/inazaruk/example/ActivityHostFragment.java
@@ -28,9 +28,9 @@ import android.view.Window;
 /**
  * This is a fragment that will be used during transition from activities to fragments.
  */
-public abstract class ActivityHostFragment extends LocalActivityManagerFragment {
+public abstract class ActivityHostFragment<T extends Activity> extends LocalActivityManagerFragment {
     
-    protected abstract Class<? extends Activity> getActivityClass();
+    protected abstract Class<T> getActivityClass();
     private final static String ACTIVITY_TAG = "hosted";
     
     @Override
@@ -59,7 +59,7 @@ public abstract class ActivityHostFragment extends LocalActivityManagerFragment 
     /**
      * For accessing public methods of the hosted activity
      */
-    public Activity getHostedActivity() {
-		return getLocalActivityManager().getActivity(ACTIVITY_TAG);
+    public T getHostedActivity() {
+		return (T) getLocalActivityManager().getActivity(ACTIVITY_TAG);
 	}
 }

--- a/map-fragment/src/com/inazaruk/example/MyMapFragment.java
+++ b/map-fragment/src/com/inazaruk/example/MyMapFragment.java
@@ -16,12 +16,10 @@
 
 package com.inazaruk.example;
 
-import android.app.Activity;
-
-public class MyMapFragment extends ActivityHostFragment {
+public class MyMapFragment extends ActivityHostFragment<MyMapActivity> {
     
     @Override
-    protected Class<? extends Activity> getActivityClass() {
+    protected Class<MyMapActivity> getActivityClass() {
         return MyMapActivity.class;
     }
 }


### PR DESCRIPTION
This pull request adds a type parameter to `ActivityHostFragment` so the `getHostedActivity` method returns the hosted activity with its specific type. This saves possible casts to the activity's specific type when calling `getHostedActivity`.

BTW, thanks for the very useful code and the StackOverflow answer :)
